### PR TITLE
ci: add tce checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,11 @@ jobs:
           kubectl apply -f ./release
 
 
+      - name: Check all YAML and README Markdown
+        run: |-
+          make check
+
+
       - name: Grype scan
         continue-on-error: true
         run: |-

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,8 @@ install:
 		-f ./src/ootb-supply-chains \
 		--data-value registry.server=foo \
 		--data-value registry.repository=bah
+
+
+check:
+	hack/check/check-mdlint.sh
+	hack/check/check-yaml.sh

--- a/README.md
+++ b/README.md
@@ -12,11 +12,9 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-
 ## Overview
 
 [carvel]-based Packaging of [Cartographer].
-
 
 ## Pre-requisites
 
@@ -24,29 +22,25 @@
 - [Tanzu CLI]
 - [cert-manager]
 
-
 ## Installation
 
-0. Submit the Package and PackageMetadata objects to the cluster
-
+First, submit the Package and PackageMetadata objects to the cluster
 
 ```bash
 kubectl apply \
   -f https://github.com/vmware-tanzu/package-for-cartographer/releases/download/v0.0.0/package.yaml
   -f https://github.com/vmware-tanzu/package-for-cartographer/releases/download/v0.0.0/package-metadata.yaml
 ```
-```console
-packagemetadata.data.packaging.carvel.dev/cartographer.community.tanzu.vmware.com created
-package.data.packaging.carvel.dev/cartographer.community.tanzu.vmware.com.0.0.0 created
-```
 
-1. Install the package
+With Package and PackageMetadata added to the Kubernetes cluster, proceed with
+installing the package:
 
 ```bash
 tanzu package install cartographer \
   --package-name cartographer.community.tanzu.vmware.com \
   --version 0.0.0
 ```
+
 ```console
 \ Installing package 'cartographer.community.tanzu.vmware.com'
 | Getting package metadata for 'cartographer.community.tanzu.vmware.com'
@@ -57,7 +51,6 @@ tanzu package install cartographer \
 / Waiting for 'PackageInstall' reconciliation for 'cartographer'
 \ 'PackageInstall' resource install status: Reconciling
 
-
  Added installed package 'cartographer'
 ```
 
@@ -66,6 +59,7 @@ Once installed, the following objects can be found in the cluster:
 ```bash
 kapp inspect -a cartographer-ctrl
 ```
+
 ```console
 Resources in app 'cartographer-ctrl'
 
@@ -102,7 +96,6 @@ cartographer-system  cartographer-controller                  Deployment
 ^
 ```
 
-
 ## Documentation
 
 This repository is solely concerned with the Packaging of Cartographer to be
@@ -112,20 +105,16 @@ For documentation specific to Cartographer, check out
 [cartographer.sh](https://cartographer.sh) and the main repository
 [vmware-tanzu/cartographer](https://github.com/vmware-tanzu/cartographer).
 
-
 ## Contributing
 
 See [./CONTRIBUTING.md](./CONTRIBUTING.md).
 
-
 ## License
 
 See [./LICENSE](./LICENSE).
-
 
 [carvel]: https://carvel.dev/
 [Cartographer]: https://cartographer.sh
 [kapp-controller]: https://github.com/vmware-tanzu/carvel-kapp-controller
 [Tanzu CLI]: https://github.com/vmware-tanzu/tanzu-framework
 [cert-manager]: https://github.com/cert-manager/cert-manager
-

--- a/hack/check/.yamllintconfig.yaml
+++ b/hack/check/.yamllintconfig.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+extends: relaxed
+
+rules:
+  line-length: disable
+  trailing-spaces: enable
+  new-line-at-end-of-file: enable
+  indentation: disable
+  key-duplicates: disable
+  empty-lines: enable
+  colons: disable
+  commas: disable
+
+ignore: |
+  /src/**/*/upstream/

--- a/hack/check/check-mdlint.sh
+++ b/hack/check/check-mdlint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+# mdlint rules with common errors and possible fixes can be found here:
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+docker run --rm -v "$(pwd)":/build \
+        gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.23.2 -- /md/lint \
+        ./README.md

--- a/hack/check/check-yaml.sh
+++ b/hack/check/check-yaml.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o nounset
+set -o pipefail
+
+CHECK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_DIR="$(dirname "${CHECK_DIR}")/.."
+
+docker run --rm -t cytopia/yamllint --version
+CONTAINER_NAME="tce_yamllint_$RANDOM"
+docker run --name ${CONTAINER_NAME} -t -v "${REPO_DIR}":/community-edition:ro cytopia/yamllint -s -c /community-edition/hack/check/.yamllintconfig.yaml /community-edition
+EXIT_CODE=$(docker inspect ${CONTAINER_NAME} --format='{{.State.ExitCode}}')
+docker rm -f ${CONTAINER_NAME} &>/dev/null
+
+if [[ ${EXIT_CODE} == "0" ]]; then
+        echo "yamllint passed!"
+else
+        echo "yamllint exit code ${EXIT_CODE}: YAML linting failed!"
+        echo "Please fix the listed yamllint errors and verify using 'make yamllint'"
+        exit "${EXIT_CODE}"
+fi


### PR DESCRIPTION
the tanzu community edition repository (main consumer of the package
produced here) runs a couple checks that we could also be running here
preemptively to make sure we get everything right (the checks are pretty
sane - despite they being the biggest consumer, I think it makes sense
to have them here regardless).

here I added only two (markdown and yaml linting) as those seem to be the
ones that could catch the really important mistakes we'd make with this
repository in particular:

- `README.md`: well, lots of text, easy to get something wrong
- YAML: the main asset produced here (`package.yaml`) 

Signed-off-by: Ciro S. Costa <ciroscosta@vmware.com>