### PR TITLE
packaging: mention cert-manager in metadata

### DIFF
--- a/packaging/package-metadata.yaml
+++ b/packaging/package-metadata.yaml
@@ -30,7 +30,7 @@ spec:
     Cartographer is a Kubernetes native Choreographer. It allows users to
     configure K8s resources into re-usable Supply Chains that can be used to
     define all of the stages that an Application Workload must go through to
-    get to an environment.
+    get to an environment. Requires cert-manager to be installed.
 
   maintainers:
     - name: VMware


### PR DESCRIPTION
the requirement of having cert-manager installed is currently the only
discoverable by looking at the docs - having it under `PackageMetadata`
allows one to discover that dependency by simply looking up the
description about the package.

Signed-off-by: Ciro S. Costa <ciroscosta@vmware.com>