### PR TITLE
hack: address kbld image mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,6 @@ copyright:
 	$(ADDLICENSE) -f ./hack/copyright.txt .
 
 
-install:
-	./hack/bundle.sh
-	ytt \
-		--ignore-unknown-comments \
-		-f ./src/ootb-supply-chains \
-		--data-value registry.server=foo \
-		--data-value registry.repository=bah
-
-
 check:
 	hack/check/check-mdlint.sh
 	hack/check/check-yaml.sh

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -46,11 +46,11 @@ show_vars() {
 create_imgpkg_bundle() {
         mkdir -p $SCRATCH/bundle/{.imgpkg,config}
 
-        cp -r ./src/cartographer/config/{objects,overlays} $SCRATCH/bundle/config
+        cp -r ./src/cartographer/config/{objects,overlays,upstream} $SCRATCH/bundle/config
         kbld \
                 -f ./src/cartographer/config/upstream \
                 --imgpkg-lock-output $SCRATCH/bundle/.imgpkg/images.yml \
-                >$SCRATCH/bundle/config/cartographer.yaml
+                >/dev/null
 
         imgpkg push -f $SCRATCH/bundle \
                 --bundle $BUNDLE \


### PR DESCRIPTION
```
    hack: preserve original upstream in bundle

    by preserving the original upstream configuration, when `kbld` passes
    through the contents of the bundle we're then able to properly have the
    image resolution taking place (as opposed to no matches).

    Signed-off-by: Ciro S. Costa <ciroscosta@vmware.com>
```

closes #11 