### PR TITLE
packaging: add explicit `-` to kbld

### DIFF
--- a/packaging/package.yaml
+++ b/packaging/package.yaml
@@ -41,6 +41,8 @@ spec:
       template:
         - ytt:
             ignoreUnknownComments: true
-        - kbld: {}
+        - kbld:
+            paths:
+              - '-'
       deploy:
         - kapp: {}


### PR DESCRIPTION
### proposed changes

make the default of `kbld: {}` explicitly set via `paths: ['-']`

### context

by default, `kbld: {}` will make use of `-` as the set of paths to look
at (i.e., for its `-f` arguments), but given that some tools validate
that paths are explicitly set for this field, have that default in here.


note that there are **no** behaviour changes with this patch.