### PR TITLE
packaging: be more explicit about ytt vs kbld

### DIFF
--- a/packaging/package.yaml
+++ b/packaging/package.yaml
@@ -41,8 +41,11 @@ spec:
       template:
         - ytt:
             ignoreUnknownComments: true
+            paths:
+              - 'config'
         - kbld:
             paths:
+              - '.imgpkg/images.yml'
               - '-'
       deploy:
         - kapp: {}


### PR DESCRIPTION
with the structure of the bundle in mind:

	bundle/
	├── .imgpkg
	│   └── images.yml
	└── config
	    ├── objects
	    │   ├── kapp
	    │   │   └── secret-ignore-rules.yaml
	    │   └── rbac
	    │       └── aggregated-roles.yaml
	    ├── overlays
	    │   └── strip-status.yaml
	    └── upstream
		└── cartographer.yaml

given that `kapp` controller will feed to `ytt` and `kbld` the contents
under `./bundle`:

- ytt:  give to it all of `config` (so that it can apply overlays, add
	extra objects, etc)
- kbld: to it, pass it the results of `ytt` _and_ `.imgpkg/images.yml`
        so it can perform any necessary image changes in the yaml it
        sees

while there is effectively no behavior changes from the previous approach,
it's more friendly to internal vmware validations.