### PR TITLE
overlays: add annotation to admission webhooks

### DIFF
--- a/src/cartographer/config/overlays/aks-webhooks.yaml
+++ b/src/cartographer/config/overlays/aks-webhooks.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#@ load("@ytt:overlay", "overlay")
+
+#@ mutating_webhook = overlay.subset({"apiVersion": "admissionregistration.k8s.io/v1", "kind": "MutatingWebhookConfiguration"})
+#@ validating_webhook = overlay.subset({"apiVersion": "admissionregistration.k8s.io/v1", "kind": "ValidatingWebhookConfiguration"})
+
+#@overlay/match by=overlay.or_op(mutating_webhook,validating_webhook), expects="0+"
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    admissions.enforcer/disabled: "true"


### PR DESCRIPTION
### proposed changes

- add a new overlay to `config/overlays/` such that we annotate our admission configuration objects with `"admissions.enforcer/disabled": true` so that when deployed in AKS, a controller that exists there don't mutate our configurations

closes #19 