### PR TITLE
cartographer: bump to 0.4.1, rm rebaserules

### DIFF
--- a/src/cartographer/config/objects/kapp/secret-ignore-rules.yaml
+++ b/src/cartographer/config/objects/kapp/secret-ignore-rules.yaml
@@ -14,14 +14,6 @@
 
 apiVersion: kapp.k14s.io/v1alpha1
 kind: Config
-rebaseRules:
-- path: [data]
-  type: copy
-  sources: [existing]
-  resourceMatchers:
-  - apiVersionKindMatcher:
-      apiVersion: v1
-      kind: Secret
 diffAgainstLastAppliedFieldExclusionRules:
 - path: [metadata, annotations]
   type: copy

--- a/src/cartographer/config/upstream/cartographer/cartographer.yaml
+++ b/src/cartographer/config/upstream/cartographer/cartographer.yaml
@@ -2786,7 +2786,7 @@ metadata:
   namespace: cartographer-system
   labels:
     app.kubernetes.io/name: cartographer-controller
-    app.kubernetes.io/version: v0.4.0
+    app.kubernetes.io/version: v0.4.1
     app.kubernetes.io/component: cartographer
 spec:
   selector:
@@ -2806,7 +2806,7 @@ spec:
             secretName: cartographer-webhook
       containers:
         - name: cartographer-controller
-          image: projectcartographer/cartographer@sha256:fbcf7877a8eeb8083bfdfa2c0c10dd53b09e87edb9704f402834e8f708ca1d51
+          image: projectcartographer/cartographer@sha256:6d15b689c362df17ea51c102a88ba96a07985a3382644e966e98d917e6417366
           args:
             - -cert-dir=/cert
           securityContext:
@@ -3148,14 +3148,5 @@ spec:
       targetPort: 9443
   selector:
     app: cartographer-controller
----
-kind: Secret
-apiVersion: v1
-metadata:
-  name: cartographer-webhook
-  namespace: cartographer-system
-  labels:
-    app.kubernetes.io/component: cartographer
-type: Opaque
 
 ---

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -16,7 +16,7 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - githubRelease:
-      url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/69549124
+      url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/69739412
     path: .
   path: ./src/cartographer/config/upstream/cartographer
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -20,7 +20,7 @@ directories:
       - path: '.'
         githubRelease:
           disableAutoChecksumValidation: true
-          tag: v0.4.0
+          tag: v0.4.1
           assetNames: ["cartographer.yaml"]
           slug: vmware-tanzu/cartographer
   - path: ./src/cartographer/config/upstream/cartographer-conventions


### PR DESCRIPTION
see https://github.com/vmware-tanzu/cartographer/pull/901

### validation

manually validated that we're able to have the ca-certificate not overwritten by 

1. creating a local release

```console
$ BUNDLE=$REGISTRY/foo ./hack/bundle.sh
```

2. modifying the packageinstall to include a cert

```yaml
apiVersion: packaging.carvel.dev/v1alpha1
kind: PackageInstall
metadata:
  name: cartographer.tanzu.vmware.com.0.0.0
  annotations:
    kapp.k14s.io/change-group: carto.run/install
    kapp.k14s.io/change-rule: upsert after upserting carto.run/meta
spec:
  serviceAccountName: default
  packageRef:
    refName: cartographer.tanzu.vmware.com
    versionSelection:
      constraints: 0.0.0
      prereleases:
        identifiers:
        - dev
        - rc
        - build
  values:
  - secretRef:
      name: cartographer-values

---
apiVersion: v1
kind: Secret
metadata:
  name: cartographer-values
stringData:
  values.yaml: |
    ca_cert_data: |
      -----BEGIN CERTIFICATE-----
      MIIEMjCCApqgAwIBAgIRAOLsZGvADp21dDJIcJUnJZ0wDQYJKoZIhvcNAQELBQAw
      IjEMMAoGA1UEBhMDVVNBMRIwEAYDVQQKEwlzZWNyZXRnZW4wHhcNMjIwNjAxMTk0
      NTM3WhcNMjUwMjI0MTk0NTM3WjAiMQwwCgYDVQQGEwNVU0ExEjAQBgNVBAoTCXNl
      Y3JldGdlbjCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoCggGBAMrQEf5tn2BS
      9HPDboD45uE09beWsIwrpbrLJrs0E0hrch3bV95x2JZNuL0UHyxr77/TIe6tWgHo
      qCiQUyEd7Ac7WkwJ12FWpdohCuBexUfVRj0x5dyh/gL8bPIiTIecUuaetPj8FG3X
      yhqm7oTopaLGCUSp8tlyxaqtkHMGZQ+BhDnK70wLMzLdzLJ7oCIGj39DFOM63JAT
      6pNS45lLhsrJP4TOqKopaKzR5JelnabUs5iXfqO1xCe46m0IIDaNVHnB5hjCP5wq
      amsm4gLedVv4oykuiwtZgH9cUW+IIjs4MVMdSj4zqH9nyevcmb0iq/tsWeqoPtBR
      +ZgkWnYKPlrp7OvcOBmc+KlYP9k4ropMla8aIDCeLeUQSP/wuzXkqMoWE8u1+CcN
      dUYMxVI/WYNQukj2g0k/VaV2eZrkomPYV3hu5GtdAZKdi2FYikLtIXME2dflsAoc
      8RqJjYvqU18GU04j0kDtgKp3HrST8D02MZ8X4UTdg9ZUgQ0IA9ejEwIDAQABo2Mw
      YTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUM5qR
      f2wYAOj2MzMAE/xzGEh5jskwHwYDVR0jBBgwFoAUM5qRf2wYAOj2MzMAE/xzGEh5
      jskwDQYJKoZIhvcNAQELBQADggGBAG03fjnpi2Re9ozxdimUPr/BmMzPL+4MosYG
      KEEUxFlJ6dxJvZ2OieSzJpRgvH9SJSVdFxzNJ/FhkdiqCougMvATGY/+5ZevJn1H
      AqsYsrhOG5UdW9fnAg+mDNUNofiio9ocwWHCAnmpHGgBWQ7bZ1tE1w2Xl5tPKQnE
      ih3H6o1J2uxhe69s0YoDKaBhFgKBNcNqSDZIBR28fMz5tV0NVNtJ57FnxSm7JHPs
      VU8DR6G1/zz1CMi4FF9dXTYCUsIvS33GNWzt4XpNWHuZUlFdBJqXIHFXtXAY0eKf
      5R+aOinO8KKQI8BBO+aJpN4XUEgKNjgw4E2Ghd61tGrqNmNUeoSmC3HyaDVZuVhm
      MN304otgdNM5TCWPPPO7VBhpxXhER6FIe/CBdfg6VQqJOJQ72IW/0WWH3eoMIpcL
      UUiOp5bLwrUiDe1ElT0Ds9OEXpKW4jAMHhV/om2wFFwrE2Ob+R/9jg1UKprej47L
      RPZe/M6VrNuifhyH3Oc+ccO/V6Of7A==
      -----END CERTIFICATE-----
```

3. observing that all goes well

```console
$ k get apps
NAME                                  DESCRIPTION           SINCE-DEPLOY   AGE
cartographer.tanzu.vmware.com.0.0.0   Reconcile succeeded   7m31s          8m9s
```

```console
$ k -n cartographer-system get secret cartographer-conventions-ca-certificates -o json | jq '.data["ca-certificates.crt"]' -r | base64 --decode
-----BEGIN CERTIFICATE-----
MIIEMjCCApqgAwIBAgIRAOLsZGvADp21dDJIcJUnJZ0wDQYJKoZIhvcNAQELBQAw
IjEMMAoGA1UEBhMDVVNBMRIwEAYDVQQKEwlzZWNyZXRnZW4wHhcNMjIwNjAxMTk0
NTM3WhcNMjUwMjI0MTk0NTM3WjAiMQwwCgYDVQQGEwNVU0ExEjAQBgNVBAoTCXNl
Y3JldGdlbjCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoCggGBAMrQEf5tn2BS
9HPDboD45uE09beWsIwrpbrLJrs0E0hrch3bV95x2JZNuL0UHyxr77/TIe6tWgHo
qCiQUyEd7Ac7WkwJ12FWpdohCuBexUfVRj0x5dyh/gL8bPIiTIecUuaetPj8FG3X
yhqm7oTopaLGCUSp8tlyxaqtkHMGZQ+BhDnK70wLMzLdzLJ7oCIGj39DFOM63JAT
6pNS45lLhsrJP4TOqKopaKzR5JelnabUs5iXfqO1xCe46m0IIDaNVHnB5hjCP5wq
amsm4gLedVv4oykuiwtZgH9cUW+IIjs4MVMdSj4zqH9nyevcmb0iq/tsWeqoPtBR
+ZgkWnYKPlrp7OvcOBmc+KlYP9k4ropMla8aIDCeLeUQSP/wuzXkqMoWE8u1+CcN
dUYMxVI/WYNQukj2g0k/VaV2eZrkomPYV3hu5GtdAZKdi2FYikLtIXME2dflsAoc
8RqJjYvqU18GU04j0kDtgKp3HrST8D02MZ8X4UTdg9ZUgQ0IA9ejEwIDAQABo2Mw
YTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUM5qR
f2wYAOj2MzMAE/xzGEh5jskwHwYDVR0jBBgwFoAUM5qRf2wYAOj2MzMAE/xzGEh5
jskwDQYJKoZIhvcNAQELBQADggGBAG03fjnpi2Re9ozxdimUPr/BmMzPL+4MosYG
KEEUxFlJ6dxJvZ2OieSzJpRgvH9SJSVdFxzNJ/FhkdiqCougMvATGY/+5ZevJn1H
AqsYsrhOG5UdW9fnAg+mDNUNofiio9ocwWHCAnmpHGgBWQ7bZ1tE1w2Xl5tPKQnE
ih3H6o1J2uxhe69s0YoDKaBhFgKBNcNqSDZIBR28fMz5tV0NVNtJ57FnxSm7JHPs
VU8DR6G1/zz1CMi4FF9dXTYCUsIvS33GNWzt4XpNWHuZUlFdBJqXIHFXtXAY0eKf
5R+aOinO8KKQI8BBO+aJpN4XUEgKNjgw4E2Ghd61tGrqNmNUeoSmC3HyaDVZuVhm
MN304otgdNM5TCWPPPO7VBhpxXhER6FIe/CBdfg6VQqJOJQ72IW/0WWH3eoMIpcL
UUiOp5bLwrUiDe1ElT0Ds9OEXpKW4jAMHhV/om2wFFwrE2Ob+R/9jg1UKprej47L
RPZe/M6VrNuifhyH3Oc+ccO/V6Of7A==
-----END CERTIFICATE-----
```

```console
$ k get cm

NAME                                                    DATA   AGE
cartographer.tanzu.vmware.com.0.0.0-ctrl                1      8m9s
cartographer.tanzu.vmware.com.0.0.0-ctrl-change-lpgfr   1      8m8s
```

```console
$ kapp inspect -a cartographer.tanzu.vmware.com.0.0.0-ctrl --tree | grep Secret

cartographer-system  pull-registry-credentials                                           Secret                          kapp     ok  -   8m
cartographer-system  cartographer-conventions-ca-certificates                            Secret                          kapp     ok  -   8m

$ k -n cartographer-system get secret

NAME                                                      TYPE                                  DATA   AGE
cartographer-controller-token-pkjwj                       kubernetes.io/service-account-token   3      9m2s
cartographer-conventions-ca-certificates                  Opaque                                1      9m2s
cartographer-conventions-controller-manager-token-v8qhl   kubernetes.io/service-account-token   3      9m2s
cartographer-webhook                                      kubernetes.io/tls                     3      9m
conventions-webhook-server-cert                           kubernetes.io/tls                     3      9m1s
default-token-98whz                                       kubernetes.io/service-account-token   3      9m4s
pull-registry-credentials                                 kubernetes.io/dockerconfigjson        1      9m2s
```
