### PR TITLE
cartographer: bump to 0.4.3

### DIFF
--- a/src/cartographer/config/upstream/cartographer/cartographer.yaml
+++ b/src/cartographer/config/upstream/cartographer/cartographer.yaml
@@ -2786,7 +2786,7 @@ metadata:
   namespace: cartographer-system
   labels:
     app.kubernetes.io/name: cartographer-controller
-    app.kubernetes.io/version: v0.4.2
+    app.kubernetes.io/version: v0.4.3
     app.kubernetes.io/component: cartographer
 spec:
   selector:
@@ -2806,7 +2806,7 @@ spec:
             secretName: cartographer-webhook
       containers:
         - name: cartographer-controller
-          image: projectcartographer/cartographer@sha256:b25649d609d0c63d31865da7b125498495cf4188144567081e4ebd19bdab6f66
+          image: projectcartographer/cartographer@sha256:43dede0337be14d019b6cc3b50aea1e4022f2c71114f75f5ffbe9730769f3b70
           args:
             - -cert-dir=/cert
           securityContext:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -16,7 +16,7 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - githubRelease:
-      url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/70766902
+      url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/72628648
     path: .
   path: ./src/cartographer/config/upstream/cartographer
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -20,7 +20,7 @@ directories:
       - path: '.'
         githubRelease:
           disableAutoChecksumValidation: true
-          tag: v0.4.2
+          tag: v0.4.3
           assetNames: ["cartographer.yaml"]
           slug: vmware-tanzu/cartographer
   - path: ./src/cartographer/config/upstream/cartographer-conventions


### PR DESCRIPTION
changes:

- backport fix "Ensure cache is also keyed by labels for runnables" (https://github.com/vmware-tanzu/cartographer/commit/7220c1a0f2c33b1b6ccd6abb67ac3877a0c0bcc1)

see https://github.com/vmware-tanzu/cartographer/releases/tag/v0.4.3

Signed-off-by: Ciro S. Costa <ciroscosta@vmware.com>