### PR TITLE
cartographer: bump to 0.5.0

### DIFF
--- a/src/cartographer/config/upstream/cartographer/cartographer.yaml
+++ b/src/cartographer/config/upstream/cartographer/cartographer.yaml
@@ -2786,7 +2786,7 @@ metadata:
   namespace: cartographer-system
   labels:
     app.kubernetes.io/name: cartographer-controller
-    app.kubernetes.io/version: v0.4.3
+    app.kubernetes.io/version: v0.5.0
     app.kubernetes.io/component: cartographer
 spec:
   selector:
@@ -2806,7 +2806,7 @@ spec:
             secretName: cartographer-webhook
       containers:
         - name: cartographer-controller
-          image: projectcartographer/cartographer@sha256:43dede0337be14d019b6cc3b50aea1e4022f2c71114f75f5ffbe9730769f3b70
+          image: projectcartographer/cartographer@sha256:c6e5bca54b39ec595f00f5646f809c9929322a603958805a2d826fd3cb2ee1f3
           args:
             - -cert-dir=/cert
           securityContext:
@@ -2858,6 +2858,12 @@ metadata:
   labels:
     app.kubernetes.io/component: cartographer
 rules:
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
   - apiGroups:
       - carto.run
     resources:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -16,7 +16,7 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - githubRelease:
-      url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/72628648
+      url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/73696928
     path: .
   path: ./src/cartographer/config/upstream/cartographer
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -20,7 +20,7 @@ directories:
       - path: '.'
         githubRelease:
           disableAutoChecksumValidation: true
-          tag: v0.4.3
+          tag: v0.5.0
           assetNames: ["cartographer.yaml"]
           slug: vmware-tanzu/cartographer
   - path: ./src/cartographer/config/upstream/cartographer-conventions


### PR DESCRIPTION
changes:

	- Cartographer now uses the TokenRequest API to obtain tokens
	  when performing actions with a specific ServiceAccount.

https://github.com/vmware-tanzu/cartographer/releases/tag/v0.5.0

Signed-off-by: Ciro S. Costa <ciroscosta@vmware.com>