### PR TITLE
overlay: handle component exclusion in set-rsrcs

### DIFF
--- a/src/cartographer/config/overlays/set-resources.yaml
+++ b/src/cartographer/config/overlays/set-resources.yaml
@@ -29,7 +29,7 @@ metadata:
   namespace: cartographer-system
 #@ end
 
-#@overlay/match by=overlay.subset(cartographer_deployment())
+#@overlay/match by=overlay.subset(cartographer_deployment()), expects="0+"
 ---
 spec:
   template:
@@ -40,7 +40,7 @@ spec:
         #@overlay/match missing_ok=True
         resources: #@ data.values.cartographer.resources
 
-#@overlay/match by=overlay.subset(conventions_deployment())
+#@overlay/match by=overlay.subset(conventions_deployment()), expects="0+"
 ---
 spec:
   template:

--- a/tests/03-test-resources-conventions.sh
+++ b/tests/03-test-resources-conventions.sh
@@ -26,6 +26,7 @@ main() {
         test_no_resources_set
         test_only_limit_memory_set
         test_requests_set
+        test_requests_set_with_component_excluded
 }
 
 # validate that we're able to make use of the
@@ -100,6 +101,21 @@ EOM
         _assert_files_equal $expected $actual
 }
 
+# validate that despite a component being excluded
+# the matching still works as expected.
+#
+test_requests_set_with_component_excluded() {
+        local actual
+
+        actual=$(
+                _apply_ytt \
+                        --data-value-yaml "conventions.resources.limits.memory=99Gi" \
+                        --data-value-yaml "excluded_components=['conventions']"
+        )
+
+        _assert_file_empty $actual
+}
+
 _apply_ytt() {
         local args=$@
         local res_fpath=$(mktemp)
@@ -121,6 +137,15 @@ _assert_files_equal() {
         local res=$(git diff --no-index $expected $actual)
         if [[ ! -z $res ]]; then
                 echo "mismatch: $res"
+        fi
+}
+
+_assert_file_empty() {
+        local fpath=$1
+
+        if [[ -s $fpath ]]; then
+                echo "expected file $fpath to be empty but wasn't"
+                exit 1
         fi
 }
 


### PR DESCRIPTION
the previous approach to matching would lead to problems when excluding
a component given that the match would fail without the expectation of
matching against something (in such case, that something would not
exist)

e.g., in `tap-values.yaml`

```diff
+++ b/hack/profiles/profile.yaml
@@ -37,3 +37,7 @@ cnrs:
 metadata_store:
   app_service_type: NodePort
   ns_for_export_app_cert: "*"
+
+cartographer:
+  excluded_components:
+    - conventions
```

then observe that `cartographer` fails to reconcile:

```
  Template:
    Error:      Templating dir: Error (see .status.usefulErrorMessage for details)
    Exit Code:  1
    Stderr:     ytt: Error: Overlaying (in following order: overlays/aks-webhooks.yaml, overlays/ca-cert-data.yaml, overlays/excluded-components.yaml, overlays/image-pull-secret.yaml, overlays/set-resources.yaml, overlays/strip-status.yaml):
  Document on line overlays/set-resources.yaml:44:
    Expected number of matched nodes to be 1, but was 0

    Updated At:          2022-08-23T21:13:39Z
  Useful Error Message:  ytt: Error: Overlaying (in following order: overlays/aks-webhooks.yaml, overlays/ca-cert-data.yaml, overlays/excluded-components.yaml, overlays/image-pull-secret.yaml, overlays/set-resources.yaml, overlays/strip-status.yaml):
  Document on line overlays/set-resources.yaml:44:
    Expected number of matched nodes to be 1, but was 0
```

with this fix otoh, we're able to have exclusions and keep `set-resources` happy