### PR TITLE
bump cartographer conventions to v0.2.2

### DIFF
--- a/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.2.yaml
+++ b/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.2.yaml
@@ -6621,8 +6621,8 @@ metadata:
     kbld.k14s.io/images: |
       - origins:
         - preresolved:
-            url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:7c978a414d136c01a86ef7ff12d6a32e70c60ea1954995efe28970951b09126e
-        url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:7c978a414d136c01a86ef7ff12d6a32e70c60ea1954995efe28970951b09126e
+            url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:2617dc33b8abde1227ade998f9835fdbfa2e868bc519596d97a327eb26ff4b46
+        url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:2617dc33b8abde1227ade998f9835fdbfa2e868bc519596d97a327eb26ff4b46
   labels:
     app.kubernetes.io/component: conventions
     control-plane: controller-manager
@@ -6648,7 +6648,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:7c978a414d136c01a86ef7ff12d6a32e70c60ea1954995efe28970951b09126e
+        image: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:2617dc33b8abde1227ade998f9835fdbfa2e868bc519596d97a327eb26ff4b46
         livenessProbe:
           httpGet:
             path: /healthz

--- a/src/cartographer/config/upstream/cartographer/cartographer.yaml
+++ b/src/cartographer/config/upstream/cartographer/cartographer.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 VMware
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.2.yaml
+++ b/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.2.yaml
@@ -53,8 +53,8 @@ metadata:
     kbld.k14s.io/images: |
       - origins:
         - preresolved:
-            url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:800d0143031f9d3ead3b96e3b699d0eeb9f1436238221cd25aaf4ee6c8585a56
-        url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:800d0143031f9d3ead3b96e3b699d0eeb9f1436238221cd25aaf4ee6c8585a56
+            url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:cee3b94cfe66e61dd798fb9bc56655ffbe8f9ab2d1da8dc87a9f79c7129162d0
+        url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:cee3b94cfe66e61dd798fb9bc56655ffbe8f9ab2d1da8dc87a9f79c7129162d0
   name: webhook
   namespace: sample-conventions
 spec:
@@ -71,7 +71,7 @@ spec:
       - env:
         - name: PORT
           value: "8443"
-        image: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:800d0143031f9d3ead3b96e3b699d0eeb9f1436238221cd25aaf4ee6c8585a56
+        image: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:cee3b94cfe66e61dd798fb9bc56655ffbe8f9ab2d1da8dc87a9f79c7129162d0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -1,17 +1,3 @@
-# Copyright 2022 VMware
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
@@ -21,12 +7,12 @@ directories:
   path: ./src/cartographer/config/upstream/cartographer
 - contents:
   - githubRelease:
-      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/73926500
+      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/81845215
     path: .
   path: ./src/cartographer/config/upstream/cartographer-conventions
 - contents:
   - githubRelease:
-      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/73926500
+      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/81845215
     path: .
   path: ./tests/01-test-convention-setup
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -28,7 +28,7 @@ directories:
       - path: '.'
         githubRelease:
           disableAutoChecksumValidation: true
-          tag: v0.2.0
+          tag: v0.2.2
           assetNames: ["cartographer-conventions-v*.yaml"]
           slug: vmware-tanzu/cartographer-conventions
   - path: ./tests/01-test-convention-setup
@@ -36,6 +36,6 @@ directories:
       - path: '.'
         githubRelease:
           disableAutoChecksumValidation: true
-          tag: v0.2.0
+          tag: v0.2.2
           assetNames: ["cartographer-conventions-samples-convention-server-v*.yaml"]
           slug: vmware-tanzu/cartographer-conventions


### PR DESCRIPTION
## Add v0.2.2 release
Reference new release of Cartographer Conventions  which makes use of the latest paketobuildpacks/run-jammy-tiny image 