### PR TITLE
bump cartographer conventions version to v0.2.3 in cartographer v0.5.x branch

### DIFF
--- a/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.3.yaml
+++ b/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.3.yaml
@@ -6621,8 +6621,8 @@ metadata:
     kbld.k14s.io/images: |
       - origins:
         - preresolved:
-            url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:2617dc33b8abde1227ade998f9835fdbfa2e868bc519596d97a327eb26ff4b46
-        url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:2617dc33b8abde1227ade998f9835fdbfa2e868bc519596d97a327eb26ff4b46
+            url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:613d489917a2b5bfc77c6aad467b6ba112eae9e5349448f0d018927410f831af
+        url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:613d489917a2b5bfc77c6aad467b6ba112eae9e5349448f0d018927410f831af
   labels:
     app.kubernetes.io/component: conventions
     control-plane: controller-manager
@@ -6648,7 +6648,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:2617dc33b8abde1227ade998f9835fdbfa2e868bc519596d97a327eb26ff4b46
+        image: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:613d489917a2b5bfc77c6aad467b6ba112eae9e5349448f0d018927410f831af
         livenessProbe:
           httpGet:
             path: /healthz

--- a/src/cartographer/config/upstream/cartographer/cartographer.yaml
+++ b/src/cartographer/config/upstream/cartographer/cartographer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 VMware
+# Copyright 2022 VMware
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/cartographer/config/upstream/cartographer/cartographer.yaml
+++ b/src/cartographer/config/upstream/cartographer/cartographer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 VMware
+# Copyright 2022-2023 VMware
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.3.yaml
+++ b/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.3.yaml
@@ -53,8 +53,8 @@ metadata:
     kbld.k14s.io/images: |
       - origins:
         - preresolved:
-            url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:cee3b94cfe66e61dd798fb9bc56655ffbe8f9ab2d1da8dc87a9f79c7129162d0
-        url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:cee3b94cfe66e61dd798fb9bc56655ffbe8f9ab2d1da8dc87a9f79c7129162d0
+            url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:921af2e406edbf2e77b9e8008d123a858e1a0768029ef0331c2dc44232529d40
+        url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:921af2e406edbf2e77b9e8008d123a858e1a0768029ef0331c2dc44232529d40
   name: webhook
   namespace: sample-conventions
 spec:
@@ -71,7 +71,7 @@ spec:
       - env:
         - name: PORT
           value: "8443"
-        image: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:cee3b94cfe66e61dd798fb9bc56655ffbe8f9ab2d1da8dc87a9f79c7129162d0
+        image: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:921af2e406edbf2e77b9e8008d123a858e1a0768029ef0331c2dc44232529d40
         livenessProbe:
           httpGet:
             path: /healthz

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 VMware
+# Copyright 2022-2023 VMware
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,20 +16,17 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - githubRelease:
-      tag: v0.5.5
       url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/90117130
     path: .
   path: ./src/cartographer/config/upstream/cartographer
 - contents:
   - githubRelease:
-      tag: v0.2.2
-      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/81845215
+      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/92580098
     path: .
   path: ./src/cartographer/config/upstream/cartographer-conventions
 - contents:
   - githubRelease:
-      tag: v0.2.2
-      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/81845215
+      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/92580098
     path: .
   path: ./tests/01-test-convention-setup
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 VMware
+# Copyright 2022-2023 VMware
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ directories:
       - path: '.'
         githubRelease:
           disableAutoChecksumValidation: true
-          tag: v0.2.2
+          tag: v0.2.3
           assetNames: ["cartographer-conventions-v*.yaml"]
           slug: vmware-tanzu/cartographer-conventions
   - path: ./tests/01-test-convention-setup
@@ -36,6 +36,6 @@ directories:
       - path: '.'
         githubRelease:
           disableAutoChecksumValidation: true
-          tag: v0.2.2
+          tag: v0.2.3
           assetNames: ["cartographer-conventions-samples-convention-server-v*.yaml"]
           slug: vmware-tanzu/cartographer-conventions


### PR DESCRIPTION
- bump conventions controller to v0.2.3 in v0.5.x branch 

- **Note** : Looks like `vendir sync` ignores the tags in the lock file 