### PR TITLE
update cartographer conventions version to v0.2.4 in 0.5.x branch

### DIFF
--- a/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.4.yaml
+++ b/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.4.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2022 VMware Inc.
+#! Copyright 2020-2023 VMware Inc.
 #!
 #! Licensed under the Apache License, Version 2.0 (the "License");
 #! you may not use this file except in compliance with the License.
@@ -6621,8 +6621,13 @@ metadata:
     kbld.k14s.io/images: |
       - origins:
         - preresolved:
+<<<<<<<< HEAD:src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.3.yaml
             url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:613d489917a2b5bfc77c6aad467b6ba112eae9e5349448f0d018927410f831af
         url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:613d489917a2b5bfc77c6aad467b6ba112eae9e5349448f0d018927410f831af
+========
+            url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:f944033e0b7790473ff6e285fc35f2e10fd3ecb8cf766b20ae4d369fba462580
+        url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:f944033e0b7790473ff6e285fc35f2e10fd3ecb8cf766b20ae4d369fba462580
+>>>>>>>> a700f52 (update cartographer conventions version):src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.4.yaml
   labels:
     app.kubernetes.io/component: conventions
     control-plane: controller-manager
@@ -6648,7 +6653,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+<<<<<<<< HEAD:src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.3.yaml
         image: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:613d489917a2b5bfc77c6aad467b6ba112eae9e5349448f0d018927410f831af
+========
+        image: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:f944033e0b7790473ff6e285fc35f2e10fd3ecb8cf766b20ae4d369fba462580
+>>>>>>>> a700f52 (update cartographer conventions version):src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.4.yaml
         livenessProbe:
           httpGet:
             path: /healthz

--- a/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.4.yaml
+++ b/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.4.yaml
@@ -6621,13 +6621,8 @@ metadata:
     kbld.k14s.io/images: |
       - origins:
         - preresolved:
-<<<<<<<< HEAD:src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.3.yaml
-            url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:613d489917a2b5bfc77c6aad467b6ba112eae9e5349448f0d018927410f831af
-        url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:613d489917a2b5bfc77c6aad467b6ba112eae9e5349448f0d018927410f831af
-========
             url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:f944033e0b7790473ff6e285fc35f2e10fd3ecb8cf766b20ae4d369fba462580
         url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:f944033e0b7790473ff6e285fc35f2e10fd3ecb8cf766b20ae4d369fba462580
->>>>>>>> a700f52 (update cartographer conventions version):src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.4.yaml
   labels:
     app.kubernetes.io/component: conventions
     control-plane: controller-manager
@@ -6653,11 +6648,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-<<<<<<<< HEAD:src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.3.yaml
-        image: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:613d489917a2b5bfc77c6aad467b6ba112eae9e5349448f0d018927410f831af
-========
         image: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:f944033e0b7790473ff6e285fc35f2e10fd3ecb8cf766b20ae4d369fba462580
->>>>>>>> a700f52 (update cartographer conventions version):src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.2.4.yaml
         livenessProbe:
           httpGet:
             path: /healthz

--- a/src/cartographer/config/upstream/cartographer/cartographer.yaml
+++ b/src/cartographer/config/upstream/cartographer/cartographer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 VMware
+# Copyright 2022-2023 VMware
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.4.yaml
+++ b/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.4.yaml
@@ -53,8 +53,13 @@ metadata:
     kbld.k14s.io/images: |
       - origins:
         - preresolved:
+<<<<<<<< HEAD:tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.3.yaml
             url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:921af2e406edbf2e77b9e8008d123a858e1a0768029ef0331c2dc44232529d40
         url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:921af2e406edbf2e77b9e8008d123a858e1a0768029ef0331c2dc44232529d40
+========
+            url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:b3de07310813a0de1a8f7607c93bfd9b76c7118e0f8f94550bfce3d7448d81b2
+        url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:b3de07310813a0de1a8f7607c93bfd9b76c7118e0f8f94550bfce3d7448d81b2
+>>>>>>>> a700f52 (update cartographer conventions version):tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.4.yaml
   name: webhook
   namespace: sample-conventions
 spec:
@@ -71,7 +76,11 @@ spec:
       - env:
         - name: PORT
           value: "8443"
+<<<<<<<< HEAD:tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.3.yaml
         image: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:921af2e406edbf2e77b9e8008d123a858e1a0768029ef0331c2dc44232529d40
+========
+        image: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:b3de07310813a0de1a8f7607c93bfd9b76c7118e0f8f94550bfce3d7448d81b2
+>>>>>>>> a700f52 (update cartographer conventions version):tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.4.yaml
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.4.yaml
+++ b/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.4.yaml
@@ -53,13 +53,8 @@ metadata:
     kbld.k14s.io/images: |
       - origins:
         - preresolved:
-<<<<<<<< HEAD:tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.3.yaml
-            url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:921af2e406edbf2e77b9e8008d123a858e1a0768029ef0331c2dc44232529d40
-        url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:921af2e406edbf2e77b9e8008d123a858e1a0768029ef0331c2dc44232529d40
-========
             url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:b3de07310813a0de1a8f7607c93bfd9b76c7118e0f8f94550bfce3d7448d81b2
         url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:b3de07310813a0de1a8f7607c93bfd9b76c7118e0f8f94550bfce3d7448d81b2
->>>>>>>> a700f52 (update cartographer conventions version):tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.4.yaml
   name: webhook
   namespace: sample-conventions
 spec:
@@ -76,11 +71,7 @@ spec:
       - env:
         - name: PORT
           value: "8443"
-<<<<<<<< HEAD:tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.3.yaml
-        image: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:921af2e406edbf2e77b9e8008d123a858e1a0768029ef0331c2dc44232529d40
-========
         image: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:b3de07310813a0de1a8f7607c93bfd9b76c7118e0f8f94550bfce3d7448d81b2
->>>>>>>> a700f52 (update cartographer conventions version):tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.2.4.yaml
         livenessProbe:
           httpGet:
             path: /healthz

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -1,22 +1,22 @@
-#! Copyright 2020-2023 VMware Inc.
-#!
-#! Licensed under the Apache License, Version 2.0 (the "License");
-#! you may not use this file except in compliance with the License.
-#! You may obtain a copy of the License at
-#!
-#!     http://www.apache.org/licenses/LICENSE-2.0
-#!
-#! Unless required by applicable law or agreed to in writing, software
-#! distributed under the License is distributed on an "AS IS" BASIS,
-#! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#! See the License for the specific language governing permissions and
-#! limitations under the License.
+# Copyright 2022-2023 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - githubRelease:
-      url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/90117130
+      url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/92898118
     path: .
   path: ./src/cartographer/config/upstream/cartographer
 - contents:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -1,35 +1,32 @@
-# Copyright 2022-2023 VMware
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#! Copyright 2020-2023 VMware Inc.
+#!
+#! Licensed under the Apache License, Version 2.0 (the "License");
+#! you may not use this file except in compliance with the License.
+#! You may obtain a copy of the License at
+#!
+#!     http://www.apache.org/licenses/LICENSE-2.0
+#!
+#! Unless required by applicable law or agreed to in writing, software
+#! distributed under the License is distributed on an "AS IS" BASIS,
+#! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#! See the License for the specific language governing permissions and
+#! limitations under the License.
 
 apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - githubRelease:
-      tag: v0.5.6
-      url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/92898118
+      url: https://api.github.com/repos/vmware-tanzu/cartographer/releases/90117130
     path: .
   path: ./src/cartographer/config/upstream/cartographer
 - contents:
   - githubRelease:
-      tag: v0.2.3
-      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/92580098
+      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/93858810
     path: .
   path: ./src/cartographer/config/upstream/cartographer-conventions
 - contents:
   - githubRelease:
-      tag: v0.2.3
-      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/92580098
+      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/93858810
     path: .
   path: ./tests/01-test-convention-setup
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -28,7 +28,7 @@ directories:
       - path: '.'
         githubRelease:
           disableAutoChecksumValidation: true
-          tag: v0.2.3
+          tag: v0.2.4
           assetNames: ["cartographer-conventions-v*.yaml"]
           slug: vmware-tanzu/cartographer-conventions
   - path: ./tests/01-test-convention-setup
@@ -36,6 +36,6 @@ directories:
       - path: '.'
         githubRelease:
           disableAutoChecksumValidation: true
-          tag: v0.2.3
+          tag: v0.2.4
           assetNames: ["cartographer-conventions-samples-convention-server-v*.yaml"]
           slug: vmware-tanzu/cartographer-conventions


### PR DESCRIPTION
bump cartographer conventions version to v0.2.4 in the  cartographer v0.5.x release branch 