### PR TITLE
Bump conventions to v0.5.0 [do not merge]

### DIFF
--- a/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.5.0.yaml
+++ b/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.5.0.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2023 VMware Inc.
+#! Copyright 2020-2022 VMware Inc.
 #!
 #! Licensed under the Apache License, Version 2.0 (the "License");
 #! you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.12.0
   labels:
     app.kubernetes.io/component: conventions
   name: clusterpodconventions.conventions.carto.run
@@ -127,7 +127,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.12.0
   labels:
     app.kubernetes.io/component: conventions
     duck.knative.dev/podspecable: "true"
@@ -953,6 +953,19 @@ spec:
                                   format: int32
                                   type: integer
                               type: object
+                            resizePolicy:
+                              items:
+                                properties:
+                                  resourceName:
+                                    type: string
+                                  restartPolicy:
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               properties:
                                 claims:
@@ -1582,6 +1595,19 @@ spec:
                                   format: int32
                                   type: integer
                               type: object
+                            resizePolicy:
+                              items:
+                                properties:
+                                  resourceName:
+                                    type: string
+                                  restartPolicy:
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               properties:
                                 claims:
@@ -2218,6 +2244,19 @@ spec:
                                   format: int32
                                   type: integer
                               type: object
+                            resizePolicy:
+                              items:
+                                properties:
+                                  resourceName:
+                                    type: string
+                                  restartPolicy:
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               properties:
                                 claims:
@@ -4197,6 +4236,19 @@ spec:
                                   format: int32
                                   type: integer
                               type: object
+                            resizePolicy:
+                              items:
+                                properties:
+                                  resourceName:
+                                    type: string
+                                  restartPolicy:
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               properties:
                                 claims:
@@ -4826,6 +4878,19 @@ spec:
                                   format: int32
                                   type: integer
                               type: object
+                            resizePolicy:
+                              items:
+                                properties:
+                                  resourceName:
+                                    type: string
+                                  restartPolicy:
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               properties:
                                 claims:
@@ -5462,6 +5527,19 @@ spec:
                                   format: int32
                                   type: integer
                               type: object
+                            resizePolicy:
+                              items:
+                                properties:
+                                  resourceName:
+                                    type: string
+                                  restartPolicy:
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               properties:
                                 claims:
@@ -6700,7 +6778,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
     app.kubernetes.io/component: conventions
   name: cartographer-conventions-manager-role
@@ -6903,8 +6980,8 @@ metadata:
     kbld.k14s.io/images: |
       - origins:
         - preresolved:
-            url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:a39e8a9f5f4a4d2b969f12958ac51c4fa4928e9349ca9c9c8cc972118d6c44b5
-        url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:a39e8a9f5f4a4d2b969f12958ac51c4fa4928e9349ca9c9c8cc972118d6c44b5
+            url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:383a5e2f17f8b437981e9fe9a066d42a33705a9a31dba2278a31c0941a88d5fd
+        url: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:383a5e2f17f8b437981e9fe9a066d42a33705a9a31dba2278a31c0941a88d5fd
   labels:
     app.kubernetes.io/component: conventions
     control-plane: controller-manager
@@ -6930,7 +7007,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:a39e8a9f5f4a4d2b969f12958ac51c4fa4928e9349ca9c9c8cc972118d6c44b5
+        image: ghcr.io/vmware-tanzu/cartographer-conventions/bundle@sha256:383a5e2f17f8b437981e9fe9a066d42a33705a9a31dba2278a31c0941a88d5fd
         livenessProbe:
           httpGet:
             path: /healthz

--- a/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.5.0.yaml
+++ b/src/cartographer/config/upstream/cartographer-conventions/cartographer-conventions-v0.5.0.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2022 VMware Inc.
+#! Copyright 2020-2023 VMware Inc.
 #!
 #! Licensed under the Apache License, Version 2.0 (the "License");
 #! you may not use this file except in compliance with the License.

--- a/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.5.0.yaml
+++ b/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.5.0.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2023 VMware Inc.
+#! Copyright 2020-2022 VMware Inc.
 #!
 #! Licensed under the Apache License, Version 2.0 (the "License");
 #! you may not use this file except in compliance with the License.
@@ -53,8 +53,8 @@ metadata:
     kbld.k14s.io/images: |
       - origins:
         - preresolved:
-            url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:d6e3dfe66d49e8deb672b3c818a1e7cebe0d647c24b16cf9901be2c750096f27
-        url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:d6e3dfe66d49e8deb672b3c818a1e7cebe0d647c24b16cf9901be2c750096f27
+            url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:b251dd1db8eaf32df8cfb580261551614c31f82e902790da54437e4bc1e2aa19
+        url: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:b251dd1db8eaf32df8cfb580261551614c31f82e902790da54437e4bc1e2aa19
   name: webhook
   namespace: sample-conventions
 spec:
@@ -71,7 +71,7 @@ spec:
       - env:
         - name: PORT
           value: "8443"
-        image: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:d6e3dfe66d49e8deb672b3c818a1e7cebe0d647c24b16cf9901be2c750096f27
+        image: ghcr.io/vmware-tanzu/cartographer-conventions/samples@sha256:b251dd1db8eaf32df8cfb580261551614c31f82e902790da54437e4bc1e2aa19
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.5.0.yaml
+++ b/tests/01-test-convention-setup/cartographer-conventions-samples-convention-server-v0.5.0.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2022 VMware Inc.
+#! Copyright 2020-2023 VMware Inc.
 #!
 #! Licensed under the Apache License, Version 2.0 (the "License");
 #! you may not use this file except in compliance with the License.

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -22,14 +22,14 @@ directories:
   path: ./src/cartographer/config/upstream/cartographer
 - contents:
   - githubRelease:
-      tag: v0.4.1
-      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/96496886
+      tag: v0.5.0
+      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/107383556
     path: .
   path: ./src/cartographer/config/upstream/cartographer-conventions
 - contents:
   - githubRelease:
-      tag: v0.4.1
-      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/96496886
+      tag: v0.5.0
+      url: https://api.github.com/repos/vmware-tanzu/cartographer-conventions/releases/107383556
     path: .
   path: ./tests/01-test-convention-setup
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -28,7 +28,7 @@ directories:
       - path: '.'
         githubRelease:
           disableAutoChecksumValidation: true
-          tag: v0.4.1
+          tag: v0.5.0
           assetNames: ["cartographer-conventions-v*.yaml"]
           slug: vmware-tanzu/cartographer-conventions
   - path: ./tests/01-test-convention-setup
@@ -36,6 +36,6 @@ directories:
       - path: '.'
         githubRelease:
           disableAutoChecksumValidation: true
-          tag: v0.4.1
+          tag: v0.5.0
           assetNames: ["cartographer-conventions-samples-convention-server-v*.yaml"]
           slug: vmware-tanzu/cartographer-conventions


### PR DESCRIPTION
Update Cartographer Conventions version to v0.5.0 - These changes are only intended for TAP 1.6.0 and not previous versions.

**Note:** This version tracks the latest updates to [Reconciler Runtime](https://github.com/vmware-labs/reconciler-runtime/releases/tag/v0.12.0) `v0.12.0`which requires [Controller Runtime](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.15.0) `v0.15.0` which in turn requires `k8s`components to be at  version `v0.27.x` 